### PR TITLE
update patches to work with the latest upstream releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,8 @@ $ curl -fsSL https://raw.githubusercontent.com/scontain/SH/master/install_sgx_dr
 ```bash
 $ curl -fsSL https://raw.githubusercontent.com/scontain/SH/master/install_sgx_driver.sh | bash -s - check -p metrics
 ```
+
+### To check whether it is necessary to create and update the patches, run:
+```bash
+$ ./run_ci.sh
+```

--- a/build-installer.sh
+++ b/build-installer.sh
@@ -11,7 +11,7 @@ export OOT_PAGE0_PATCH_VERSION=1
 
 export OOT_VERSION_PATCH_CONTENT=$(cat patches/oot-version.patch | sed 's/\\$/\\@!-tbs-!@/g')
 export OOT_DKMS_PATCH_CONTENT=$(cat patches/oot-dkms.patch | sed 's/\\$/\\@!-tbs-!@/g')
-export OOT_COMMIT_SHA="4505f07271ed82230fce55b8d0d820dbc7a27c5a"
+export OOT_COMMIT_SHA="0373e2e8b96d9a261657b7657cb514f003f67094"
 
 # DCAP
 export DCAP_REPOSITORY="https://github.com/intel/SGXDataCenterAttestationPrimitives.git"
@@ -20,7 +20,7 @@ export DCAP_METRICS_PATCH_CONTENT=$(cat patches/dcap-metrics.patch | sed 's/\\$/
 export DCAP_METRICS_PATCH_VERSION=1
 
 export DCAP_VERSION_PATCH_CONTENT=$(cat patches/dcap-version.patch | sed 's/\\$/\\@!-tbs-!@/g')
-export DCAP_COMMIT_SHA="c9b707408d14fc1f1dcc519950bafb8bc58f0f42"
+export DCAP_COMMIT_SHA="30fac05232e13eab72c425a7788fafa5a46b3247"
 
 echo -n "INFO: Creating install_sgx_driver.sh... "
 envsubst < install_sgx_driver.tmpl '\

--- a/install_sgx_driver.sh
+++ b/install_sgx_driver.sh
@@ -31,10 +31,10 @@ set -e
 
 # OOT Patches
 oot_metrics_patch_content=$(cat << 'METRICS_PATCH_EOF'
-From 3b47ff9dde963f0a45d577b1905f9569f686f0e7 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?F=C3=A1bio=20Silva?= <fabio@scontain.com>
-Date: Wed, 2 Sep 2020 14:28:23 -0300
-Subject: [PATCH] Add metrics extension
+From 1c6b7b56b09e65d0242a11ff8ddc1cda652ee7a5 Mon Sep 17 00:00:00 2001
+From: "pamenas" <mpamenas@gmail.com>
+Date: Mon, 15 Feb 2021 18:56:21 +0100
+Subject: [PATCH] applied scone oot metrics patch
 
 ---
  sgx.h            |  2 ++
@@ -239,16 +239,16 @@ index 0000000..643f7ab
 +    echo "$metric= `cat $MODPATH/$metric`"
 +done
 -- 
-2.25.1
+2.17.1
 METRICS_PATCH_EOF
 )
 oot_metrics_patch_version=2
 
 oot_page0_patch_content=$(cat << 'PAGE0_PATCH_EOF'
-From f3848b151d90140d79738e7ca60613640925fe16 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?F=C3=A1bio=20Silva?= <fabio@scontain.com>
-Date: Wed, 2 Sep 2020 14:23:33 -0300
-Subject: [PATCH] Add page0 extension
+From 65c42999f78152dfcb0301a35768a3fd344fbee1 Mon Sep 17 00:00:00 2001
+From: "pamenas" <mpamenas@gmail.com>
+Date: Mon, 15 Feb 2021 18:59:33 +0100
+Subject: [PATCH] applied scone page0 patch
 
 ---
  sgx.h      | 2 ++
@@ -317,16 +317,16 @@ index 4ff4e2b..f9488b2 100644
  	return addr;
  }
 -- 
-2.25.1
+2.17.1
 PAGE0_PATCH_EOF
 )
 oot_page0_patch_version=1
 
 oot_version_patch_content=$(cat << 'VERSION_PATCH_EOF'
-From 8fff875dd7aef0b484a4fd0e8f4b526bf691c736 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?F=C3=A1bio=20Silva?= <fabio@scontain.com>
-Date: Wed, 2 Sep 2020 14:19:08 -0300
-Subject: [PATCH] Add version extension
+From 9f301e9e8d7f1152cc9766343fba38c1e35ff6fb Mon Sep 17 00:00:00 2001
+From: "pamenas" <mpamenas@gmail.com>
+Date: Mon, 15 Feb 2021 19:00:36 +0100
+Subject: [PATCH] applied scone version patch
 
 ---
  sgx_main.c | 27 +++++++++++++++++++++++++++
@@ -378,15 +378,15 @@ index 4ff4e2b..3a58f6c 100644
  {
  	vma->vm_ops = &sgx_vm_ops;
 -- 
-2.25.1
+2.17.1
 VERSION_PATCH_EOF
 )
 
 oot_dkms_patch_content=$(cat << 'DKMS_PATCH_EOF'
-From 79b42a5974f371b34625023e644b36d4fa4f5871 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?F=C3=A1bio=20Silva?= <fabio@scontain.com>
-Date: Wed, 2 Sep 2020 14:27:49 -0300
-Subject: [PATCH] Add DKMS support
+From a0c2cf98e13693e669827abf00d9ae13ede0bf3b Mon Sep 17 00:00:00 2001
+From: "pamenas" <mpamenas@gmail.com>
+Date: Mon, 15 Feb 2021 19:06:18 +0100
+Subject: [PATCH] applied scone dkms patch
 
 ---
  dkms.conf | 6 ++++++
@@ -395,7 +395,7 @@ Subject: [PATCH] Add DKMS support
 
 diff --git a/dkms.conf b/dkms.conf
 new file mode 100644
-index 0000000..9c03f4a
+index 0000000..9c1a256
 --- /dev/null
 +++ b/dkms.conf
 @@ -0,0 +1,6 @@
@@ -406,32 +406,32 @@ index 0000000..9c03f4a
 +AUTOINSTALL="yes"
 +MAKE[0]="'make'  KDIR=/lib/modules/${kernelver}/build"
 -- 
-2.25.1
+2.17.1
 DKMS_PATCH_EOF
 )
 
 # DCAP Patches
 dcap_metrics_patch_content=$(cat << 'METRICS_PATCH_EOF'
-From 911a08cd6e96eba66a629ba80871c6b0c5c830f0 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?F=C3=A1bio=20Silva?= <fabio@scontain.com>
-Date: Wed, 2 Sep 2020 00:45:58 -0300
-Subject: [PATCH] Add metrics extension
+From 1e7f9567b5def9e4741afc4e92c37908ab91c53e Mon Sep 17 00:00:00 2001
+From: "pamenas" <mpamenas@gmail.com>
+Date: Mon, 15 Feb 2021 18:33:49 +0100
+Subject: [PATCH] applied scone metrics changes to driver
 
 ---
  driver/linux/driver.h       |  2 ++
- driver/linux/encl.c         | 18 ++++++++++++++++++
- driver/linux/ioctl.c        | 12 ++++++++++++
- driver/linux/main.c         | 26 ++++++++++++++++++++++++++
+ driver/linux/encl.c         | 17 ++++++++++++++++-
+ driver/linux/ioctl.c        | 12 ++++++++++--
+ driver/linux/main.c         | 25 +++++++++++++++++++++++++
  driver/linux/show_values.sh | 23 +++++++++++++++++++++++
- 5 files changed, 81 insertions(+)
+ 5 files changed, 76 insertions(+), 3 deletions(-)
  create mode 100755 driver/linux/show_values.sh
 
 diff --git a/driver/linux/driver.h b/driver/linux/driver.h
-index c90e132..c47fd79 100644
+index 4024f48..28a6590 100644
 --- a/driver/linux/driver.h
 +++ b/driver/linux/driver.h
 @@ -12,6 +12,8 @@
- #include "uapi/asm/sgx_oot.h"
+ #include "sgx_user.h"
  #include "sgx.h"
  
 +#define PATCH_METRICS 1
@@ -440,15 +440,15 @@ index c90e132..c47fd79 100644
  #define SGX_EINIT_SLEEP_COUNT	50
  #define SGX_EINIT_SLEEP_TIME	20
 diff --git a/driver/linux/encl.c b/driver/linux/encl.c
-index ebac232..02c14b0 100644
+index b9746c5..089310f 100644
 --- a/driver/linux/encl.c
 +++ b/driver/linux/encl.c
-@@ -14,6 +14,18 @@
+@@ -13,7 +13,18 @@
+ #include "sgx.h"
  #include "dcap.h"
- 
  #include <linux/version.h>
 +#include <linux/moduleparam.h>
-+
+ 
 +extern unsigned int sgx_nr_enclaves;
 +static unsigned int sgx_nr_low_pages = SGX_NR_LOW_PAGES;
 +static unsigned int sgx_nr_high_pages = SGX_NR_HIGH_PAGES;
@@ -460,28 +460,28 @@ index ebac232..02c14b0 100644
 +module_param(sgx_loaded_back, uint, 0440);
 +module_param(sgx_nr_marked_old, uint, 0440);
  
- static int __sgx_encl_eldu(struct sgx_encl_page *encl_page,
- 			   struct sgx_epc_page *epc_page,
-@@ -55,6 +67,8 @@ static int __sgx_encl_eldu(struct sgx_encl_page *encl_page,
+ /*
+  * ELDU: Load an EPC page as unblocked. For more info, see "OS Management of EPC
+@@ -58,6 +69,8 @@ static int __sgx_encl_eldu(struct sgx_encl_page *encl_page,
  		ret = -EFAULT;
  	}
  
-+	sgx_loaded_back++;
++    sgx_loaded_back++;
 +
  	kunmap_atomic((void *)(unsigned long)(pginfo.metadata - b.pcmd_offset));
  	kunmap_atomic((void *)(unsigned long)pginfo.contents);
  
-@@ -616,6 +630,9 @@ void sgx_encl_release(struct kref *ref)
- {
- 	struct sgx_encl *encl = container_of(ref, struct sgx_encl, refcount);
- 
-+	if (atomic_read(&encl->flags) & SGX_ENCL_CREATED)
-+		sgx_nr_enclaves--;
-+
- 	sgx_encl_destroy(encl);
- 
- 	if (encl->backing)
-@@ -716,6 +733,7 @@ static int sgx_encl_test_and_clear_young_cb(pte_t *ptep,
+@@ -473,7 +486,8 @@ void sgx_encl_release(struct kref *ref)
+ #else
+ 	unsigned long index;
+ #endif
+-
++	if (test_bit(SGX_ENCL_CREATED, &encl->flags))
++        sgx_nr_enclaves--;
+ #if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 20, 0))
+ 	radix_tree_for_each_slot(slot, &encl->page_tree, &iter, 0) {
+ 		entry = *slot;
+@@ -748,6 +762,7 @@ static int sgx_encl_test_and_clear_young_cb(pte_t *ptep,
  	ret = pte_young(*ptep);
  	if (ret) {
  		pte = pte_mkold(*ptep);
@@ -490,15 +490,15 @@ index ebac232..02c14b0 100644
  	}
  
 diff --git a/driver/linux/ioctl.c b/driver/linux/ioctl.c
-index 1ca7612..ffaabb8 100644
+index e8aa47a..9d3532a 100644
 --- a/driver/linux/ioctl.c
 +++ b/driver/linux/ioctl.c
-@@ -18,6 +18,14 @@
+@@ -17,7 +17,14 @@
+ #include "encls.h"
  
  #include <linux/version.h>
- #include "sgx_wl.h"
 +#include <linux/moduleparam.h>
-+
+ 
 +unsigned int sgx_init_enclaves = 0;
 +unsigned int sgx_nr_enclaves = 0;
 +unsigned int sgx_nr_added_pages = 0;
@@ -506,48 +506,34 @@ index 1ca7612..ffaabb8 100644
 +module_param(sgx_nr_enclaves, uint, 0440);
 +module_param(sgx_nr_added_pages, uint, 0440);
  
- /* A per-cpu cache for the last known values of IA32_SGXLEPUBKEYHASHx MSRs. */
- static DEFINE_PER_CPU(u64 [4], sgx_lepubkeyhash_cache);
-@@ -190,6 +198,7 @@ static int sgx_encl_create(struct sgx_encl *encl, struct sgx_secs *secs)
- 	 */
- 	atomic_or(SGX_ENCL_CREATED, &encl->flags);
+ static struct sgx_va_page *sgx_encl_grow(struct sgx_encl *encl)
+ {
+@@ -116,8 +123,8 @@ static int sgx_encl_create(struct sgx_encl *encl, struct sgx_secs *secs)
+ 	encl->attributes_mask = SGX_ATTR_DEBUG | SGX_ATTR_MODE64BIT | SGX_ATTR_KSS;
  
-+	sgx_nr_enclaves++;
+ 	/* Set only after completion, as encl->lock has not been taken. */
+-	set_bit(SGX_ENCL_CREATED, &encl->flags);
+-
++	set_bit(SGX_ENCL_CREATED, &encl->flags);
++    sgx_nr_enclaves++;
  	return 0;
  
  err_out:
-@@ -431,6 +440,8 @@ static int sgx_encl_add_page(struct sgx_encl *encl, unsigned long src,
- 	if (ret)
- 		goto err_out;
- 
-+	sgx_nr_added_pages++;
-+
- 	/*
- 	 * Complete the "add" before doing the "extend" so that the "add"
- 	 * isn't in a half-baked state in the extremely unlikely scenario the
-@@ -709,6 +720,7 @@ static int sgx_encl_init(struct sgx_encl *encl, struct sgx_sigstruct *sigstruct,
+@@ -603,6 +610,7 @@ static int sgx_encl_init(struct sgx_encl *encl, struct sgx_sigstruct *sigstruct,
  		ret = -EPERM;
  	} else {
- 		atomic_or(SGX_ENCL_INITIALIZED, &encl->flags);
+ 		set_bit(SGX_ENCL_INITIALIZED, &encl->flags);
 +		sgx_init_enclaves++;
  	}
  
  err_out:
 diff --git a/driver/linux/main.c b/driver/linux/main.c
-index bd0c821..758b173 100644
+index a75969b..65cc9b1 100644
 --- a/driver/linux/main.c
 +++ b/driver/linux/main.c
-@@ -16,6 +16,7 @@
- #include <linux/module.h>
- #include "version.h"
- #include "dcap.h"
-+#include <linux/moduleparam.h>
- #ifndef MSR_IA32_FEAT_CTL
- #define MSR_IA32_FEAT_CTL MSR_IA32_FEATURE_CONTROL
- #endif
-@@ -30,6 +31,16 @@ static DECLARE_WAIT_QUEUE_HEAD(ksgxswapd_waitq);
- static LIST_HEAD(sgx_active_page_list);
- static DEFINE_SPINLOCK(sgx_active_page_list_lock);
+@@ -31,6 +31,16 @@ static int sgx_nr_epc_sections;
+ static struct task_struct *ksgxd_tsk;
+ static DECLARE_WAIT_QUEUE_HEAD(ksgxd_waitq);
  
 +static unsigned int sgx_nr_total_epc_pages = 0;
 +static unsigned int sgx_nr_alloc_pages = 0;
@@ -559,26 +545,26 @@ index bd0c821..758b173 100644
 +module_param(sgx_nr_reclaimed, uint, 0440);
 +module_param(sgx_nr_evicted, uint, 0440);
 +
- /**
-  * sgx_mark_page_reclaimable() - Mark a page as reclaimable
-  * @page:	EPC page
-@@ -319,6 +330,7 @@ static void sgx_reclaimer_write(struct sgx_epc_page *epc_page,
- 			if (ret)
- 				goto out;
+ /*
+  * These variables are part of the state of the reclaimer, and must be accessed
+  * with sgx_reclaimer_lock acquired.
+@@ -302,6 +312,7 @@ static void sgx_reclaimer_write(struct sgx_epc_page *epc_page,
+ 		if (ret)
+ 			goto out;
  
-+			sgx_nr_evicted++;  // races are acceptable..
- 			sgx_encl_ewb(encl->secs.epc_page, &secs_backing);
++		sgx_nr_evicted++;
+ 		sgx_encl_ewb(encl->secs.epc_page, &secs_backing);
  
- 			sgx_free_epc_page(encl->secs.epc_page);
-@@ -384,6 +396,7 @@ static void sgx_reclaim_pages(void)
+ 		sgx_free_epc_page(encl->secs.epc_page);
+@@ -373,6 +384,7 @@ static void sgx_reclaim_pages(void)
  
  		mutex_lock(&encl_page->encl->lock);
- 		encl_page->desc |= SGX_ENCL_PAGE_RECLAIMED;
+ 		encl_page->desc |= SGX_ENCL_PAGE_BEING_RECLAIMED;
 +		sgx_nr_reclaimed++;
  		mutex_unlock(&encl_page->encl->lock);
  		continue;
  
-@@ -462,6 +475,17 @@ static unsigned long sgx_nr_free_pages(void)
+@@ -423,6 +435,17 @@ static unsigned long sgx_nr_free_pages(void)
  	return cnt;
  }
  
@@ -596,15 +582,15 @@ index bd0c821..758b173 100644
  static bool sgx_should_reclaim(unsigned long watermark)
  {
  	return sgx_nr_free_pages() < watermark &&
-@@ -642,6 +666,7 @@ struct sgx_epc_page *sgx_alloc_epc_page(void *owner, bool reclaim)
- 		schedule();
+@@ -644,6 +667,7 @@ struct sgx_epc_page *sgx_alloc_epc_page(void *owner, bool reclaim)
+ 		cond_resched();
  	}
  
-+	sgx_nr_alloc_pages++; // ignore races..
++	sgx_nr_alloc_pages++; // ignore races ..
  	if (sgx_should_reclaim(SGX_NR_LOW_PAGES))
- 		wake_up(&ksgxswapd_waitq);
+ 		wake_up(&ksgxd_waitq);
  
-@@ -780,6 +805,7 @@ static bool __init sgx_page_cache_init(void)
+@@ -746,6 +770,7 @@ static bool __init sgx_page_cache_init(void)
  		}
  
  		sgx_nr_epc_sections++;
@@ -642,26 +628,26 @@ index 0000000..af9e2d8
 +    echo "$metric= `cat $MODPATH/$metric`"
 +done
 -- 
-2.25.1
+2.17.1
 METRICS_PATCH_EOF
 )
 dcap_metrics_patch_version=1
 
 dcap_version_patch_content=$(cat << 'VERSION_PATCH_EOF'
-From 3f0cded6c144236c784ce0f75c75b5dce803bbd6 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?F=C3=A1bio=20Silva?= <fabio@scontain.com>
-Date: Wed, 2 Sep 2020 01:21:47 -0300
-Subject: [PATCH] Add version extension
+From 98165f4fb6ad99c64e368891198ce1384ec96f8e Mon Sep 17 00:00:00 2001
+From: "pamenas" <mpamenas@gmail.com>
+Date: Mon, 15 Feb 2021 12:55:59 +0100
+Subject: [PATCH] applied scone dcap version patch
 
 ---
  driver/linux/main.c | 28 ++++++++++++++++++++++++++++
  1 file changed, 28 insertions(+)
 
 diff --git a/driver/linux/main.c b/driver/linux/main.c
-index bd0c821..0748255 100644
+index a75969b..0cb41bb 100644
 --- a/driver/linux/main.c
 +++ b/driver/linux/main.c
-@@ -523,6 +523,34 @@ static bool __init sgx_page_reclaimer_init(void)
+@@ -480,6 +480,34 @@ static bool __init sgx_page_reclaimer_init(void)
  	return true;
  }
  
@@ -697,13 +683,13 @@ index bd0c821..0748255 100644
  static bool detect_sgx(struct cpuinfo_x86 *c)
  {
 -- 
-2.25.1
+2.17.1
 VERSION_PATCH_EOF
 )
 
 # OOT & DCAP Commits
-oot_driver_commit="4505f07271ed82230fce55b8d0d820dbc7a27c5a"
-dcap_driver_commit="c9b707408d14fc1f1dcc519950bafb8bc58f0f42"
+oot_driver_commit="0373e2e8b96d9a261657b7657cb514f003f67094"
+dcap_driver_commit="30fac05232e13eab72c425a7788fafa5a46b3247"
 
 # print the right color for each level
 #

--- a/patches/dcap-metrics.patch
+++ b/patches/dcap-metrics.patch
@@ -1,23 +1,23 @@
-From 911a08cd6e96eba66a629ba80871c6b0c5c830f0 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?F=C3=A1bio=20Silva?= <fabio@scontain.com>
-Date: Wed, 2 Sep 2020 00:45:58 -0300
-Subject: [PATCH] Add metrics extension
+From 1e7f9567b5def9e4741afc4e92c37908ab91c53e Mon Sep 17 00:00:00 2001
+From: "pamenas" <mpamenas@gmail.com>
+Date: Mon, 15 Feb 2021 18:33:49 +0100
+Subject: [PATCH] applied scone metrics changes to driver
 
 ---
  driver/linux/driver.h       |  2 ++
- driver/linux/encl.c         | 18 ++++++++++++++++++
- driver/linux/ioctl.c        | 12 ++++++++++++
- driver/linux/main.c         | 26 ++++++++++++++++++++++++++
+ driver/linux/encl.c         | 17 ++++++++++++++++-
+ driver/linux/ioctl.c        | 12 ++++++++++--
+ driver/linux/main.c         | 25 +++++++++++++++++++++++++
  driver/linux/show_values.sh | 23 +++++++++++++++++++++++
- 5 files changed, 81 insertions(+)
+ 5 files changed, 76 insertions(+), 3 deletions(-)
  create mode 100755 driver/linux/show_values.sh
 
 diff --git a/driver/linux/driver.h b/driver/linux/driver.h
-index c90e132..c47fd79 100644
+index 4024f48..28a6590 100644
 --- a/driver/linux/driver.h
 +++ b/driver/linux/driver.h
 @@ -12,6 +12,8 @@
- #include "uapi/asm/sgx_oot.h"
+ #include "sgx_user.h"
  #include "sgx.h"
  
 +#define PATCH_METRICS 1
@@ -26,15 +26,15 @@ index c90e132..c47fd79 100644
  #define SGX_EINIT_SLEEP_COUNT	50
  #define SGX_EINIT_SLEEP_TIME	20
 diff --git a/driver/linux/encl.c b/driver/linux/encl.c
-index ebac232..02c14b0 100644
+index b9746c5..089310f 100644
 --- a/driver/linux/encl.c
 +++ b/driver/linux/encl.c
-@@ -14,6 +14,18 @@
+@@ -13,7 +13,18 @@
+ #include "sgx.h"
  #include "dcap.h"
- 
  #include <linux/version.h>
 +#include <linux/moduleparam.h>
-+
+ 
 +extern unsigned int sgx_nr_enclaves;
 +static unsigned int sgx_nr_low_pages = SGX_NR_LOW_PAGES;
 +static unsigned int sgx_nr_high_pages = SGX_NR_HIGH_PAGES;
@@ -46,28 +46,28 @@ index ebac232..02c14b0 100644
 +module_param(sgx_loaded_back, uint, 0440);
 +module_param(sgx_nr_marked_old, uint, 0440);
  
- static int __sgx_encl_eldu(struct sgx_encl_page *encl_page,
- 			   struct sgx_epc_page *epc_page,
-@@ -55,6 +67,8 @@ static int __sgx_encl_eldu(struct sgx_encl_page *encl_page,
+ /*
+  * ELDU: Load an EPC page as unblocked. For more info, see "OS Management of EPC
+@@ -58,6 +69,8 @@ static int __sgx_encl_eldu(struct sgx_encl_page *encl_page,
  		ret = -EFAULT;
  	}
  
-+	sgx_loaded_back++;
++    sgx_loaded_back++;
 +
  	kunmap_atomic((void *)(unsigned long)(pginfo.metadata - b.pcmd_offset));
  	kunmap_atomic((void *)(unsigned long)pginfo.contents);
  
-@@ -616,6 +630,9 @@ void sgx_encl_release(struct kref *ref)
- {
- 	struct sgx_encl *encl = container_of(ref, struct sgx_encl, refcount);
- 
-+	if (atomic_read(&encl->flags) & SGX_ENCL_CREATED)
-+		sgx_nr_enclaves--;
-+
- 	sgx_encl_destroy(encl);
- 
- 	if (encl->backing)
-@@ -716,6 +733,7 @@ static int sgx_encl_test_and_clear_young_cb(pte_t *ptep,
+@@ -473,7 +486,8 @@ void sgx_encl_release(struct kref *ref)
+ #else
+ 	unsigned long index;
+ #endif
+-
++	if (test_bit(SGX_ENCL_CREATED, &encl->flags))
++        sgx_nr_enclaves--;
+ #if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 20, 0))
+ 	radix_tree_for_each_slot(slot, &encl->page_tree, &iter, 0) {
+ 		entry = *slot;
+@@ -748,6 +762,7 @@ static int sgx_encl_test_and_clear_young_cb(pte_t *ptep,
  	ret = pte_young(*ptep);
  	if (ret) {
  		pte = pte_mkold(*ptep);
@@ -76,15 +76,15 @@ index ebac232..02c14b0 100644
  	}
  
 diff --git a/driver/linux/ioctl.c b/driver/linux/ioctl.c
-index 1ca7612..ffaabb8 100644
+index e8aa47a..9d3532a 100644
 --- a/driver/linux/ioctl.c
 +++ b/driver/linux/ioctl.c
-@@ -18,6 +18,14 @@
+@@ -17,7 +17,14 @@
+ #include "encls.h"
  
  #include <linux/version.h>
- #include "sgx_wl.h"
 +#include <linux/moduleparam.h>
-+
+ 
 +unsigned int sgx_init_enclaves = 0;
 +unsigned int sgx_nr_enclaves = 0;
 +unsigned int sgx_nr_added_pages = 0;
@@ -92,48 +92,34 @@ index 1ca7612..ffaabb8 100644
 +module_param(sgx_nr_enclaves, uint, 0440);
 +module_param(sgx_nr_added_pages, uint, 0440);
  
- /* A per-cpu cache for the last known values of IA32_SGXLEPUBKEYHASHx MSRs. */
- static DEFINE_PER_CPU(u64 [4], sgx_lepubkeyhash_cache);
-@@ -190,6 +198,7 @@ static int sgx_encl_create(struct sgx_encl *encl, struct sgx_secs *secs)
- 	 */
- 	atomic_or(SGX_ENCL_CREATED, &encl->flags);
+ static struct sgx_va_page *sgx_encl_grow(struct sgx_encl *encl)
+ {
+@@ -116,8 +123,8 @@ static int sgx_encl_create(struct sgx_encl *encl, struct sgx_secs *secs)
+ 	encl->attributes_mask = SGX_ATTR_DEBUG | SGX_ATTR_MODE64BIT | SGX_ATTR_KSS;
  
-+	sgx_nr_enclaves++;
+ 	/* Set only after completion, as encl->lock has not been taken. */
+-	set_bit(SGX_ENCL_CREATED, &encl->flags);
+-
++	set_bit(SGX_ENCL_CREATED, &encl->flags);
++    sgx_nr_enclaves++;
  	return 0;
  
  err_out:
-@@ -431,6 +440,8 @@ static int sgx_encl_add_page(struct sgx_encl *encl, unsigned long src,
- 	if (ret)
- 		goto err_out;
- 
-+	sgx_nr_added_pages++;
-+
- 	/*
- 	 * Complete the "add" before doing the "extend" so that the "add"
- 	 * isn't in a half-baked state in the extremely unlikely scenario the
-@@ -709,6 +720,7 @@ static int sgx_encl_init(struct sgx_encl *encl, struct sgx_sigstruct *sigstruct,
+@@ -603,6 +610,7 @@ static int sgx_encl_init(struct sgx_encl *encl, struct sgx_sigstruct *sigstruct,
  		ret = -EPERM;
  	} else {
- 		atomic_or(SGX_ENCL_INITIALIZED, &encl->flags);
+ 		set_bit(SGX_ENCL_INITIALIZED, &encl->flags);
 +		sgx_init_enclaves++;
  	}
  
  err_out:
 diff --git a/driver/linux/main.c b/driver/linux/main.c
-index bd0c821..758b173 100644
+index a75969b..65cc9b1 100644
 --- a/driver/linux/main.c
 +++ b/driver/linux/main.c
-@@ -16,6 +16,7 @@
- #include <linux/module.h>
- #include "version.h"
- #include "dcap.h"
-+#include <linux/moduleparam.h>
- #ifndef MSR_IA32_FEAT_CTL
- #define MSR_IA32_FEAT_CTL MSR_IA32_FEATURE_CONTROL
- #endif
-@@ -30,6 +31,16 @@ static DECLARE_WAIT_QUEUE_HEAD(ksgxswapd_waitq);
- static LIST_HEAD(sgx_active_page_list);
- static DEFINE_SPINLOCK(sgx_active_page_list_lock);
+@@ -31,6 +31,16 @@ static int sgx_nr_epc_sections;
+ static struct task_struct *ksgxd_tsk;
+ static DECLARE_WAIT_QUEUE_HEAD(ksgxd_waitq);
  
 +static unsigned int sgx_nr_total_epc_pages = 0;
 +static unsigned int sgx_nr_alloc_pages = 0;
@@ -145,26 +131,26 @@ index bd0c821..758b173 100644
 +module_param(sgx_nr_reclaimed, uint, 0440);
 +module_param(sgx_nr_evicted, uint, 0440);
 +
- /**
-  * sgx_mark_page_reclaimable() - Mark a page as reclaimable
-  * @page:	EPC page
-@@ -319,6 +330,7 @@ static void sgx_reclaimer_write(struct sgx_epc_page *epc_page,
- 			if (ret)
- 				goto out;
+ /*
+  * These variables are part of the state of the reclaimer, and must be accessed
+  * with sgx_reclaimer_lock acquired.
+@@ -302,6 +312,7 @@ static void sgx_reclaimer_write(struct sgx_epc_page *epc_page,
+ 		if (ret)
+ 			goto out;
  
-+			sgx_nr_evicted++;  // races are acceptable..
- 			sgx_encl_ewb(encl->secs.epc_page, &secs_backing);
++		sgx_nr_evicted++;
+ 		sgx_encl_ewb(encl->secs.epc_page, &secs_backing);
  
- 			sgx_free_epc_page(encl->secs.epc_page);
-@@ -384,6 +396,7 @@ static void sgx_reclaim_pages(void)
+ 		sgx_free_epc_page(encl->secs.epc_page);
+@@ -373,6 +384,7 @@ static void sgx_reclaim_pages(void)
  
  		mutex_lock(&encl_page->encl->lock);
- 		encl_page->desc |= SGX_ENCL_PAGE_RECLAIMED;
+ 		encl_page->desc |= SGX_ENCL_PAGE_BEING_RECLAIMED;
 +		sgx_nr_reclaimed++;
  		mutex_unlock(&encl_page->encl->lock);
  		continue;
  
-@@ -462,6 +475,17 @@ static unsigned long sgx_nr_free_pages(void)
+@@ -423,6 +435,17 @@ static unsigned long sgx_nr_free_pages(void)
  	return cnt;
  }
  
@@ -182,15 +168,15 @@ index bd0c821..758b173 100644
  static bool sgx_should_reclaim(unsigned long watermark)
  {
  	return sgx_nr_free_pages() < watermark &&
-@@ -642,6 +666,7 @@ struct sgx_epc_page *sgx_alloc_epc_page(void *owner, bool reclaim)
- 		schedule();
+@@ -644,6 +667,7 @@ struct sgx_epc_page *sgx_alloc_epc_page(void *owner, bool reclaim)
+ 		cond_resched();
  	}
  
-+	sgx_nr_alloc_pages++; // ignore races..
++	sgx_nr_alloc_pages++; // ignore races ..
  	if (sgx_should_reclaim(SGX_NR_LOW_PAGES))
- 		wake_up(&ksgxswapd_waitq);
+ 		wake_up(&ksgxd_waitq);
  
-@@ -780,6 +805,7 @@ static bool __init sgx_page_cache_init(void)
+@@ -746,6 +770,7 @@ static bool __init sgx_page_cache_init(void)
  		}
  
  		sgx_nr_epc_sections++;
@@ -228,5 +214,5 @@ index 0000000..af9e2d8
 +    echo "$metric= `cat $MODPATH/$metric`"
 +done
 -- 
-2.25.1
+2.17.1
 

--- a/patches/dcap-version.patch
+++ b/patches/dcap-version.patch
@@ -1,17 +1,17 @@
-From 3f0cded6c144236c784ce0f75c75b5dce803bbd6 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?F=C3=A1bio=20Silva?= <fabio@scontain.com>
-Date: Wed, 2 Sep 2020 01:21:47 -0300
-Subject: [PATCH] Add version extension
+From 98165f4fb6ad99c64e368891198ce1384ec96f8e Mon Sep 17 00:00:00 2001
+From: "pamenas" <mpamenas@gmail.com>
+Date: Mon, 15 Feb 2021 12:55:59 +0100
+Subject: [PATCH] applied scone dcap version patch
 
 ---
  driver/linux/main.c | 28 ++++++++++++++++++++++++++++
  1 file changed, 28 insertions(+)
 
 diff --git a/driver/linux/main.c b/driver/linux/main.c
-index bd0c821..0748255 100644
+index a75969b..0cb41bb 100644
 --- a/driver/linux/main.c
 +++ b/driver/linux/main.c
-@@ -523,6 +523,34 @@ static bool __init sgx_page_reclaimer_init(void)
+@@ -480,6 +480,34 @@ static bool __init sgx_page_reclaimer_init(void)
  	return true;
  }
  
@@ -47,5 +47,5 @@ index bd0c821..0748255 100644
  static bool detect_sgx(struct cpuinfo_x86 *c)
  {
 -- 
-2.25.1
+2.17.1
 

--- a/patches/oot-dkms.patch
+++ b/patches/oot-dkms.patch
@@ -1,7 +1,7 @@
-From 79b42a5974f371b34625023e644b36d4fa4f5871 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?F=C3=A1bio=20Silva?= <fabio@scontain.com>
-Date: Wed, 2 Sep 2020 14:27:49 -0300
-Subject: [PATCH] Add DKMS support
+From a0c2cf98e13693e669827abf00d9ae13ede0bf3b Mon Sep 17 00:00:00 2001
+From: "pamenas" <mpamenas@gmail.com>
+Date: Mon, 15 Feb 2021 19:06:18 +0100
+Subject: [PATCH] applied scone dkms patch
 
 ---
  dkms.conf | 6 ++++++
@@ -10,7 +10,7 @@ Subject: [PATCH] Add DKMS support
 
 diff --git a/dkms.conf b/dkms.conf
 new file mode 100644
-index 0000000..9c03f4a
+index 0000000..9c1a256
 --- /dev/null
 +++ b/dkms.conf
 @@ -0,0 +1,6 @@
@@ -21,5 +21,5 @@ index 0000000..9c03f4a
 +AUTOINSTALL="yes"
 +MAKE[0]="'make'  KDIR=/lib/modules/${kernelver}/build"
 -- 
-2.25.1
+2.17.1
 

--- a/patches/oot-metrics.patch
+++ b/patches/oot-metrics.patch
@@ -1,7 +1,7 @@
-From 3b47ff9dde963f0a45d577b1905f9569f686f0e7 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?F=C3=A1bio=20Silva?= <fabio@scontain.com>
-Date: Wed, 2 Sep 2020 14:28:23 -0300
-Subject: [PATCH] Add metrics extension
+From 1c6b7b56b09e65d0242a11ff8ddc1cda652ee7a5 Mon Sep 17 00:00:00 2001
+From: "pamenas" <mpamenas@gmail.com>
+Date: Mon, 15 Feb 2021 18:56:21 +0100
+Subject: [PATCH] applied scone oot metrics patch
 
 ---
  sgx.h            |  2 ++
@@ -206,5 +206,5 @@ index 0000000..643f7ab
 +    echo "$metric= `cat $MODPATH/$metric`"
 +done
 -- 
-2.25.1
+2.17.1
 

--- a/patches/oot-page0.patch
+++ b/patches/oot-page0.patch
@@ -1,7 +1,7 @@
-From f3848b151d90140d79738e7ca60613640925fe16 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?F=C3=A1bio=20Silva?= <fabio@scontain.com>
-Date: Wed, 2 Sep 2020 14:23:33 -0300
-Subject: [PATCH] Add page0 extension
+From 65c42999f78152dfcb0301a35768a3fd344fbee1 Mon Sep 17 00:00:00 2001
+From: "pamenas" <mpamenas@gmail.com>
+Date: Mon, 15 Feb 2021 18:59:33 +0100
+Subject: [PATCH] applied scone page0 patch
 
 ---
  sgx.h      | 2 ++
@@ -70,5 +70,5 @@ index 4ff4e2b..f9488b2 100644
  	return addr;
  }
 -- 
-2.25.1
+2.17.1
 

--- a/patches/oot-version.patch
+++ b/patches/oot-version.patch
@@ -1,7 +1,7 @@
-From 8fff875dd7aef0b484a4fd0e8f4b526bf691c736 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?F=C3=A1bio=20Silva?= <fabio@scontain.com>
-Date: Wed, 2 Sep 2020 14:19:08 -0300
-Subject: [PATCH] Add version extension
+From 9f301e9e8d7f1152cc9766343fba38c1e35ff6fb Mon Sep 17 00:00:00 2001
+From: "pamenas" <mpamenas@gmail.com>
+Date: Mon, 15 Feb 2021 19:00:36 +0100
+Subject: [PATCH] applied scone version patch
 
 ---
  sgx_main.c | 27 +++++++++++++++++++++++++++
@@ -53,5 +53,5 @@ index 4ff4e2b..3a58f6c 100644
  {
  	vma->vm_ops = &sgx_vm_ops;
 -- 
-2.25.1
+2.17.1
 


### PR DESCRIPTION
The patches and support scripts have been updated and tested to be able to install the most recent upstream intel sgx drivers.