### PR TITLE
do not error out when sourcing config file for provisioning

### DIFF
--- a/5.8.0-rc.19/kubectl-provision
+++ b/5.8.0-rc.19/kubectl-provision
@@ -1173,8 +1173,9 @@ function print_vault_keys {
 }
 
 # NOTE: verbose will only show up if you execute with "V=1 ./kubectl-kubectl"
+set +e
 source "$CONFIG_FILE" 2>/dev/null || verbose "Note: could not load config file \"$CONFIG_FILE\" - Ignoring."
-
+set -e
 
 function post_provisioning() {
     export SVCNAME=`kubectl get svc --namespace "$NAMESPACE" --selector "app.kubernetes.io/instance=$NAME,app.kubernetes.io/name=cas" | tail -1 | awk '{ print $1 }'`


### PR DESCRIPTION
Currently, the `kubectl-provision` errors our when it can find no config file. 
This fixes this behaviour for version 5.8.0-rc.19